### PR TITLE
hts-927 prevent double click of submit buttons

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -1,3 +1,4 @@
+@import 'partials/_colors';
 @import 'partials/_header';
 @import 'partials/_section';
 @import 'partials/_dividers';

--- a/app/assets/stylesheets/partials/_buttons.scss
+++ b/app/assets/stylesheets/partials/_buttons.scss
@@ -1,9 +1,3 @@
-$black: #0b0c0c;
-$grey-8: #DEE0E2;
-$text-colour: $black;
-$white: #fff;
-
-
 @mixin border-radius($radius) {
   -webkit-border-radius: $radius; // Chrome 4.0, Safari 3.1 to 4.0, Mobile Safari 3.2, Android Browser 2.1
      -moz-border-radius: $radius; // Firefox 2.0 to 3.6

--- a/app/assets/stylesheets/partials/_colors.scss
+++ b/app/assets/stylesheets/partials/_colors.scss
@@ -1,0 +1,5 @@
+$black: #0b0c0c;
+$border-colour: #bfc1c3;
+$grey-8: #DEE0E2;
+$text-colour: $black;
+$white: #fff;

--- a/app/assets/stylesheets/partials/_dividers.scss
+++ b/app/assets/stylesheets/partials/_dividers.scss
@@ -20,8 +20,6 @@ Discussion: https://hmrcdigital.hackpad.com/Dividers-M7xA1gwZOqv
 Styleguide Dividers
 */
 
-$border-colour: #bfc1c3;
-
 .divider--top {
   border-top: 1px solid $border-colour;
 }

--- a/app/assets/stylesheets/partials/_header.scss
+++ b/app/assets/stylesheets/partials/_header.scss
@@ -1,4 +1,5 @@
-.js-enabled #global-cookie-message {
+.js-enabled #global-cookie-message,
+.service-info {
   display: none !important;
 }
 
@@ -73,9 +74,12 @@
           }
 
           .header__menu__proposition-name {
+            color: $black;
             display: block;
             font-size: 20px;
             font-weight: bold;
+            height: 32px;
+            line-height: 32px;
           }
         }
       }

--- a/app/assets/stylesheets/partials/_section.scss
+++ b/app/assets/stylesheets/partials/_section.scss
@@ -27,3 +27,11 @@ Styleguide Section.Sub Section
 .subsection {
   margin: 1.5em 0;
 }
+
+/*
+  Overwrite set width on the .content__body element
+*/
+.content__body {
+  float: none !important;
+  width: 100% !important;
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -137,7 +137,7 @@ google-analytics {
 
 
 assets {
-  version = "4.2.1"
+  version = "3.2.1"
   version = ${?ASSETS_FRONTEND_VERSION}
   url = "http://localhost:9032/assets/"
 }


### PR DESCRIPTION
Downgraded Assets Frontend to 3.2.1 to enable the preventDoubleSubmit javascript module.